### PR TITLE
Fixed bug with pdf -> html opener for ios

### DIFF
--- a/assets/js/modules/PDFViewer/PDFViewer.js
+++ b/assets/js/modules/PDFViewer/PDFViewer.js
@@ -10,7 +10,7 @@ export default class PDFViewer {
         this.pdfPath = pdfPath;
 
         if (this.isIOS()) {
-            const htmlLoader = new HTMLLoader(container, htmlPath);
+            const htmlLoader = new HTMLLoader(container, htmlPath, this.observable);
             htmlLoader.load();
         } else {
             this.init();


### PR DESCRIPTION
I needed to pass the observe object to the html loader.